### PR TITLE
Add Docker environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@
 > This installation was tested on: Ubuntu 22.04, CUDA 12.8, Python 3.12, NVIDIA RTX 5090.
 > For common hardware and environment questions, see [FAQ.md](FAQ.md).
 
+### 🐳 Option 1: Docker (Recommended)
+
+We provide a prebuilt environment image at [`docker.io/amapcvlab/abot-world:v0-env`](https://hub.docker.com/r/amapcvlab/abot-world), so you can skip the manual installation below. The image contains the runtime environment only; the repository and checkpoints are mounted at runtime:
+
+```bash
+git clone https://github.com/amap-cvlab/ABot-World.git
+cd ABot-World
+
+# Download checkpoints (see "Download checkpoints" below), then:
+docker pull amapcvlab/abot-world:v0-env
+IMAGE=amapcvlab/abot-world:v0-env bash docker/run.sh
+```
+
+Alternatively, build the image yourself with `bash docker/build.sh`. See [docker/README.md](docker/README.md) for build options, volume mounts, and troubleshooting.
+
+### 🔧 Option 2: Manual Installation
+
 1. Clone the repository:
 
 ```bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,103 @@
+# =============================================================================
+# ABot-World Docker image
+#
+# Follows the installation steps in README.md (Setup section):
+#   Ubuntu 22.04 + CUDA 12.8 + Python 3.12 + PyTorch 2.8.0 (cu128)
+#   + FlashAttention 2.8.1 (prebuilt wheel)
+#   + SageAttention (built from source)
+#   + lightx2v_kernel (built from source, requires CUTLASS)
+#
+# Build (run from the repository root):
+#   docker build -f docker/Dockerfile -t abot-world:latest .
+# or simply:
+#   bash docker/build.sh
+# =============================================================================
+
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+
+# CUDA architectures for SageAttention (works without a GPU at build time).
+#   8.6 -> RTX 3090, 8.9 -> RTX 4090, 9.0 -> H100/H20, 12.0 -> RTX 5090
+# Note: lightx2v_kernel is compiled for sm_120a (Blackwell) only, as upstream.
+ARG TORCH_CUDA_ARCH_LIST="8.6;8.9;9.0;12.0"
+# Parallel compile jobs. CAUTION: SageAttention's build parallelism multiplies
+# (EXT_PARALLEL x MAX_JOBS ninja jobs x nvcc --threads), and each compile unit
+# can peak at 3-6 GB RAM. The defaults below keep peak usage under ~30 GB.
+ARG MAX_JOBS=4
+# Miniconda installer URL; override for faster mirrors, e.g. TUNA:
+#   https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/Miniconda3-latest-Linux-x86_64.sh
+ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# ── System dependencies ──────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git wget curl ca-certificates build-essential ninja-build \
+        ffmpeg libgl1 libglib2.0-0 libsm6 libxext6 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Conda environment (Python 3.12, as in README) ────────────────────────────
+RUN wget --progress=dot:giga "${MINICONDA_URL}" -O /tmp/miniconda.sh \
+    && bash /tmp/miniconda.sh -b -p /opt/conda \
+    && rm /tmp/miniconda.sh \
+    # Accept Anaconda channel ToS non-interactively (no-op on older conda)
+    && { /opt/conda/bin/conda tos accept --override-channels \
+           --channel https://repo.anaconda.com/pkgs/main \
+           --channel https://repo.anaconda.com/pkgs/r || true; } \
+    && /opt/conda/bin/conda create -n aworld python=3.12 -y \
+    && /opt/conda/bin/conda clean -afy
+ENV PATH=/opt/conda/envs/aworld/bin:/opt/conda/bin:$PATH
+
+# ── PyTorch (CUDA 12.8) ──────────────────────────────────────────────────────
+RUN pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 \
+        --index-url https://download.pytorch.org/whl/cu128
+
+# ── FlashAttention (prebuilt wheel) ──────────────────────────────────────────
+# NOTE: keep the original wheel filename; pip rejects renamed wheels.
+RUN wget --progress=dot:giga -P /tmp \
+        "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.1/flash_attn-2.8.1+cu12torch2.8cxx11abiFALSE-cp312-cp312-linux_x86_64.whl" \
+    && pip install "/tmp/flash_attn-2.8.1+cu12torch2.8cxx11abiFALSE-cp312-cp312-linux_x86_64.whl" \
+    && rm /tmp/flash_attn-*.whl
+
+# ── SageAttention (from source) ──────────────────────────────────────────────
+RUN pip install packaging ninja \
+    && git clone --depth 1 https://github.com/thu-ml/SageAttention.git /tmp/SageAttention \
+    && cd /tmp/SageAttention \
+    # EXT_PARALLEL=1: build extensions sequentially; --threads 2 overrides the
+    # hardcoded --threads=8 in setup.py to bound per-nvcc memory.
+    && EXT_PARALLEL=1 NVCC_APPEND_FLAGS="--threads 2" MAX_JOBS=${MAX_JOBS} \
+       TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
+       python setup.py install \
+    && rm -rf /tmp/SageAttention
+
+# ── Python dependencies ──────────────────────────────────────────────────────
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+# ── lightx2v_kernel (from source, requires CUTLASS) ──────────────────────────
+RUN pip install uv \
+    && git clone --depth 1 https://github.com/NVIDIA/cutlass.git /tmp/cutlass \
+    && git clone --depth 1 https://github.com/ModelTC/LightX2V.git /tmp/LightX2V \
+    && cd /tmp/LightX2V/lightx2v_kernel \
+    && MAX_JOBS=${MAX_JOBS} CMAKE_BUILD_PARALLEL_LEVEL=${MAX_JOBS} \
+       uv build --wheel \
+           -Cbuild-dir=build . \
+           -Ccmake.define.CUTLASS_PATH=/tmp/cutlass \
+           --color=always \
+           --no-build-isolation \
+    && pip install dist/*.whl --force-reinstall --no-deps \
+    && rm -rf /tmp/cutlass /tmp/LightX2V
+
+# ── Checkpoint download tools (used at runtime, see docker/README.md) ────────
+RUN pip install -U huggingface_hub modelscope
+
+# ── Project mount point ─────────────────────────────────────────────────────────────
+# The image contains only the runtime environment; the ABot-World repository
+# is mounted here at runtime (see docker/run.sh).
+WORKDIR /workspace/ABot-World
+
+# Gradio demo port (web_client/config.py: SERVER_PORT = 2233)
+EXPOSE 2233
+
+CMD ["bash", "web_client/run.sh"]

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+# BuildKit Dockerfile-specific ignore file (applies when building with
+# `docker build -f docker/Dockerfile .` and BuildKit enabled).
+# The image only needs requirements.txt from the build context;
+# project code is mounted at runtime (see docker/run.sh).
+*
+!requirements.txt

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,127 @@
+# ABot-World Docker
+
+Run ABot-World in a reproducible container instead of installing the
+environment manually. The image follows the [Setup](../README.md#%EF%B8%8F-setup)
+section of the main README:
+
+- Ubuntu 22.04, CUDA 12.8, Python 3.12 (conda)
+- PyTorch 2.8.0 / torchvision 0.23.0 / torchaudio 2.8.0 (cu128)
+- FlashAttention 2.8.1 (prebuilt wheel)
+- SageAttention (built from source)
+- `lightx2v_kernel` (built from source against CUTLASS)
+- All Python dependencies from `requirements.txt`
+
+> The image contains **only the runtime environment** — the ABot-World
+> repository is mounted into the container at runtime, so always launch it
+> from a local clone of this repo (e.g. via `docker/run.sh`). Code changes on
+> the host take effect immediately without rebuilding the image.
+
+## Prerequisites
+
+- Docker with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+- An NVIDIA GPU with a driver supporting CUDA 12.8 (tested on RTX 5090; see [FAQ.md](../FAQ.md) for RTX 3090/4090 notes)
+- At least 64 GB of system RAM recommended
+
+## 1. Get the image
+
+### Use the prebuilt image (recommended)
+
+A prebuilt environment image is available on Docker Hub — no compilation needed:
+
+```bash
+docker pull amapcvlab/abot-world:v0-env
+```
+
+Then pass it to `run.sh` via `IMAGE` (see step 3): `IMAGE=amapcvlab/abot-world:v0-env bash docker/run.sh`
+
+### Or build it yourself
+
+From the repository root:
+
+```bash
+bash docker/build.sh
+```
+
+Or directly:
+
+```bash
+docker build -f docker/Dockerfile -t abot-world:latest .
+```
+
+Build options (passed as environment variables to `build.sh` or as
+`--build-arg` to `docker build`):
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `TORCH_CUDA_ARCH_LIST` | `8.6;8.9;9.0;12.0` | CUDA architectures compiled for SageAttention. Use `12.0` to build for RTX 5090 only (faster build). |
+| `MAX_JOBS` | `4` | Parallel compilation jobs for the source builds. SageAttention's build parallelism multiplies internally and each compile unit can peak at 3-6 GB RAM; raise this only on hosts with plenty of RAM (OOM will hang the machine). |
+
+> Note: `lightx2v_kernel` is compiled for `sm_120a` (Blackwell, e.g. RTX 5090)
+> only, following the upstream LightX2V build configuration.
+
+## 2. Download checkpoints
+
+Checkpoints are not baked into the image. Download them to `./checkpoints`
+on the host (they are mounted into the container by `docker/run.sh`):
+
+```bash
+# HuggingFace
+hf download acvlab/ABot-World-0-5B-LF --local-dir ./checkpoints/ABot-World-0-5B-LF
+
+# or ModelScope
+modelscope download "amap_cvlab/ABot-World-0-5B-LF" --local_dir ./checkpoints/ABot-World-0-5B-LF
+```
+
+If you prefer to download inside the container (both `huggingface_hub` and
+`modelscope` are preinstalled):
+
+```bash
+bash docker/run.sh bash
+hf download acvlab/ABot-World-0-5B-LF --local-dir ./checkpoints/ABot-World-0-5B-LF
+```
+
+## 3. Run the Gradio demo
+
+```bash
+bash docker/run.sh
+```
+
+Then open `http://localhost:2233` in your browser (Chrome recommended).
+
+Runtime options:
+
+```bash
+CUDA_ID=1 bash docker/run.sh        # select a GPU
+PORT=8080 bash docker/run.sh        # map a different host port
+IMAGE=abot-world:v0.1 bash docker/run.sh
+bash docker/run.sh bash             # interactive shell inside the container
+```
+
+Equivalent raw `docker run` command:
+
+```bash
+docker run --rm -it --gpus all \
+  --ipc=host --shm-size=32GB \
+  --ulimit nofile=65536:65536 \
+  -v "$(pwd):/workspace/ABot-World" \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -p 2233:2233 \
+  abot-world:latest
+```
+
+## Mounted volumes
+
+| Host path | Container path | Purpose |
+| --- | --- | --- |
+| `.` (repo root) | `/workspace/ABot-World` | Project code, `checkpoints/`, `outputs/` |
+| `~/.cache/huggingface` | `/root/.cache/huggingface` | HuggingFace cache (tokenizers, downloads) |
+
+## Troubleshooting
+
+- **`could not select device driver "nvidia"`** — the NVIDIA Container
+  Toolkit is not installed or Docker was not restarted after installation.
+- **CUDA errors from `lightx2v_kernel` on non-Blackwell GPUs** — the
+  quantized kernels target `sm_120a`; see [FAQ.md](../FAQ.md) for hardware
+  compatibility notes.
+- **Port already in use** — change the host port with `PORT=<port> bash docker/run.sh`.
+- For other environment questions, see [FAQ.md](../FAQ.md).

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Build the ABot-World Docker image.
+#
+# Usage:
+#   bash docker/build.sh                             # default image tag abot-world:latest
+#   IMAGE=abot-world:v0.1 bash docker/build.sh       # custom image tag
+#   TORCH_CUDA_ARCH_LIST="12.0" bash docker/build.sh # build SageAttention for RTX 5090 only (faster)
+#   MINICONDA_URL=<mirror-url> bash docker/build.sh  # use a Miniconda mirror (e.g. TUNA)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMAGE="${IMAGE:-abot-world:latest}"
+TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-8.6;8.9;9.0;12.0}"
+# CAUTION: SageAttention's build parallelism multiplies (see docker/Dockerfile);
+# raise MAX_JOBS only on hosts with plenty of RAM.
+MAX_JOBS="${MAX_JOBS:-4}"
+
+echo "=== Building ABot-World Docker image ==="
+echo "  Image:               $IMAGE"
+echo "  TORCH_CUDA_ARCH_LIST: $TORCH_CUDA_ARCH_LIST"
+echo "  MAX_JOBS:            $MAX_JOBS"
+echo "========================================="
+
+DOCKER_BUILDKIT=1 docker build \
+    -f "$SCRIPT_DIR/Dockerfile" \
+    --build-arg TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
+    --build-arg MAX_JOBS="$MAX_JOBS" \
+    ${MINICONDA_URL:+--build-arg MINICONDA_URL="$MINICONDA_URL"} \
+    ${HTTP_PROXY:+--build-arg HTTP_PROXY="$HTTP_PROXY"} \
+    ${HTTPS_PROXY:+--build-arg HTTPS_PROXY="$HTTPS_PROXY"} \
+    ${NO_PROXY:+--build-arg NO_PROXY="$NO_PROXY"} \
+    -t "$IMAGE" \
+    "$PROJECT_ROOT"
+
+echo "Done. Run the demo with: bash docker/run.sh"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Run the ABot-World Gradio demo inside Docker.
+#
+# Usage:
+#   bash docker/run.sh                       # start the Gradio demo on GPU 0
+#   CUDA_ID=1 bash docker/run.sh             # select a GPU
+#   PORT=8080 bash docker/run.sh             # map a different host port
+#   bash docker/run.sh bash                  # drop into an interactive shell
+#
+# Requirements: Docker with the NVIDIA Container Toolkit installed.
+# The image contains only the runtime environment: this script mounts the
+# whole repository (including ./checkpoints) into the container, so it must
+# be run from a local clone of ABot-World (see docker/README.md).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMAGE="${IMAGE:-abot-world:latest}"
+PORT="${PORT:-2233}"
+CUDA_ID="${CUDA_ID:-0}"
+
+mkdir -p "$PROJECT_ROOT/checkpoints" "$PROJECT_ROOT/outputs" "$HOME/.cache/huggingface"
+
+echo "=== ABot-World Docker ==="
+echo "  Image: $IMAGE"
+echo "  GPU:   CUDA_ID=$CUDA_ID"
+echo "  Port:  http://localhost:$PORT"
+echo "========================="
+
+docker run --rm -it \
+    --gpus all \
+    --ipc=host \
+    --shm-size=32GB \
+    --ulimit nofile=65536:65536 \
+    -e CUDA_ID="$CUDA_ID" \
+    -v "$PROJECT_ROOT:/workspace/ABot-World" \
+    -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
+    -p "$PORT:2233" \
+    "$IMAGE" \
+    "$@"


### PR DESCRIPTION
- Add docker/Dockerfile: CUDA 12.8 + Python 3.12 environment with PyTorch, FlashAttention, SageAttention and lightx2v_kernel (environment-only image; repository and checkpoints are mounted at runtime)
- Add docker/build.sh and docker/run.sh helper scripts with OOM-safe compile parallelism defaults
- Add docker/README.md usage guide and Dockerfile.dockerignore
- README.md: document Docker installation option with prebuilt image docker.io/amapcvlab/abot-world:v0-env