### PR TITLE
Detect Hopper for FlashAttention 3 by compute capability, not GPU name (H200/H800/H20 silently fell back to FA2)

### DIFF
--- a/wan/modules/attention.py
+++ b/wan/modules/attention.py
@@ -5,11 +5,16 @@ try:
     import flash_attn_interface
 
     def is_hopper_gpu():
-        """flashattn-hopper 仅支持 Hopper (H100)，不支持 Blackwell，故只检测 Hopper。"""
+        """flashattn-hopper targets sm_90 only (Hopper, not Blackwell).
+
+        Detect by compute capability rather than by product name: H200, H800
+        and H20 are sm_90 too, but their names contain neither "h100" nor
+        "hopper", so a name check silently routed them to FlashAttention 2.
+        """
         if not torch.cuda.is_available():
             return False
-        device_name = torch.cuda.get_device_name(0).lower()
-        return "h100" in device_name or "hopper" in device_name
+        major, _ = torch.cuda.get_device_capability(0)
+        return major == 9
     FLASH_ATTN_3_AVAILABLE = is_hopper_gpu()
 except ModuleNotFoundError:
     FLASH_ATTN_3_AVAILABLE = False


### PR DESCRIPTION
## Problem

`wan/modules/attention.py` enables FlashAttention 3 only when the GPU name contains `h100` or `hopper`:

```python
device_name = torch.cuda.get_device_name(0).lower()
return "h100" in device_name or "hopper" in device_name
```

`torch.cuda.get_device_name()` reports product names such as `NVIDIA H200`, `NVIDIA H800` and `NVIDIA H20`. None of them match, so on those Hopper parts `FLASH_ATTN_3_AVAILABLE` is `False` and every attention call silently takes the FlashAttention 2 path, even with `flash_attn_interface` installed. Nothing is logged, so the slowdown is easy to miss.

## Change

Detect Hopper by compute capability, `torch.cuda.get_device_capability(0)[0] == 9`, which is what the flashattn-hopper build targets (sm_90). H100 behaviour is unchanged; H200/H800/H20 now use FA3 when it is installed; Blackwell (major 10 and 12) still returns `False`, as the original comment intends. The docstring says why.

## Verification

On an H100 80GB SXM the flag evaluates to `True` before and after the change (same kernels, same output). The device-name strings above are what `torch.cuda.get_device_name()` returns for those parts, which is what makes the old check fail there. The same name check exists in other Wan-derived repositories; we carry the identical fix in our DreamX-World deployment.
